### PR TITLE
config/locales/ 配下に、ja.yml を設置

### DIFF
--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,13 @@
+# ↓「日本語」ということを宣言
+ja:
+  # ↓activerecord関連(つまりDBに関連)する項目ということを宣言
+  activerecord:
+    # ↓model名(つまりテーブル名)を宣言
+    models:
+      article: 記事
+
+    # ↓modelのattribute名(つまりテーブル名のカラム名)を宣言
+    attributes:
+      article:
+        title: タイトル
+        content: 本文


### PR DESCRIPTION
## 概要
 - Rails を日本語化するために、 gem install rails-i18n -v '~> 6.0' を実行
 - config/locales/ 配下に、ja.yml を設置